### PR TITLE
Create [백준2577번].java

### DIFF
--- a/[백준2577번].java
+++ b/[백준2577번].java
@@ -1,0 +1,30 @@
+// 백준 2577번_ 숫자의 개수 
+
+import java.util.Scanner;
+
+public class 숫자의 개수 {
+  public static void main(String[] args) {
+   
+   Scanner sc = new Scanner(System.in);
+   int a, b, c = 0;
+   
+   a = sc.nextInt();
+   b = sc.nextInt();
+   c = sc.nextInt();
+   x = a * b * c
+   
+   String str = Integer.toString(x);
+  
+   for (i = 0; i < 10; i++) {
+    int count = 0;
+    for(j = 0; j < str.length(); j++) {
+      if((str.charAt(j)-'0')==i) {
+        count++
+        }
+    }System.out.println(count); 
+   } 
+  }  
+ }   
+   
+   
+  


### PR DESCRIPTION
for 문으로 i를 순회하며 if문으로 str의 j번째 숫자를 비교할 때 왜 -'0'을 써줘야 하는지 궁금했다.  
찾아보니 CharAt(int index)로 추출한 숫자형 문자는 char형이므로 int형으로 변환 시 아스키코드로 변환된다고 한다. 
따라서 '0'(48)을 빼주어야 의도한 리턴값을 얻을 수 있다.